### PR TITLE
Pass op CLI --raw instead of --output=raw

### DIFF
--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -290,7 +290,7 @@ func (m *Meta) NewOnePassClient() (*OnePassClient, error) {
 }
 
 func (o *OnePassClient) SignIn() error {
-	cmd := exec.Command(o.PathToOp, "signin", o.Subdomain, o.Email, o.SecretKey, "--output=raw")
+	cmd := exec.Command(o.PathToOp, "signin", o.Subdomain, o.Email, o.SecretKey, "--raw")
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return err


### PR DESCRIPTION
Avoid error:

```
│ Error: Cannot signin: [ERROR] 2022/09/15 10:55:56 unknown flag: --output
│ Usage:  op signin [flags]
│
│ Examples:
│ Sign in and set the environment variable in one step:
│
│ 	eval $(op signin --account acme.1password.com)
│
│ Flags:
│   -f, --force   Ignore warnings and print raw output from this command.
│   -h, --help    Get help with signin.
│       --raw     Only return the session token.
│
│ Global Flags:
│       --account account    Select the account to execute the command by account shorthand, sign-in address, account ID, or user ID. For a list
│                            of available accounts, run 'op account list'. Can be set as the OP_ACCOUNT environment variable.
│       --cache              Store and use cached information.
│       --config directory   Use this configuration directory.
│       --debug              Output debug logs. Can also be set using $OP_DEBUG environment variable.
│       --encoding type      Use this character encoding type. Default: UTF-8. Supported: SHIFT_JIS, gbk.
│       --format string      Use this output format. Can be 'human-readable' or 'json'. Can be set as the OP_FORMAT environment variable.
│                            (default "human-readable")
│   -h, --help               Get help for op.
│       --iso-timestamps     Format timestamps according to ISO 8601 / RFC 3339. Can be set as the OP_ISO_TIMESTAMPS environment variable.
│       --no-color           Print output without color.
│       --session token      Authenticate with this session token. 1Password CLI outputs session tokens for successful 'op signin' commands when
│                            biometric unlock is disabled.
│
│ Exit code: exit status 1
│
│   with provider["registry.terraform.io/afresh-technologies/onepassword"],
│   on provider-onepassword.tf line 7, in provider "onepassword":
│    7: provider "onepassword" {
```